### PR TITLE
Replace deprecated `single_month_title` function call with own function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+####v 2.1.3 / 2023-05-25
+* FIXED: SSL issues, deprecations
+
 #### v 2.1.2 / 2023-02-03
 * REMOVED: Remove REST API /disconnectSite endpoint (#150)
 

--- a/classicpress-seo.php
+++ b/classicpress-seo.php
@@ -265,6 +265,7 @@ class Classic_SEO {
 	private function includes() {
 		include dirname( __FILE__ ) . '/vendor/autoload.php';
 		require_once( dirname( __FILE__ ) . '/includes/class-update-client.php' );
+		require_once( dirname( __FILE__ ) . '/includes/class-update-client-tweaks.php' );
 	}
 
 	/**
@@ -321,10 +322,6 @@ class Classic_SEO {
 			add_action( 'plugins_loaded', [ $this, 'init_wp_cli' ], 20 );
 		}
 
-		// Fix images folder for Update Manager.
-		add_filter( 'codepotent_update_manager_image_path', [ $this, 'fix_update_manager_images' ] );
-		add_filter( 'codepotent_update_manager_image_url', [ $this, 'fix_update_manager_images' ] );
-
 	}
 
 	/**
@@ -362,13 +359,6 @@ class Classic_SEO {
 	 */
 	public function init_wp_cli() {
 		WP_CLI::add_command( 'cpseo sitemap generate', [ '\Classic_SEO\CLI\Commands', 'sitemap_generate' ] );
-	}
-
-	/**
-	 * Fix images folder for Update Manager.
-	 */
-	public function fix_update_manager_images( $folder ) {
-		return preg_replace( '/' . basename( CPSEO_PATH ) . '\/images$/', basename( CPSEO_PATH ) . '/assets/images', $folder );
 	}
 
 	/**

--- a/classicpress-seo.php
+++ b/classicpress-seo.php
@@ -3,7 +3,7 @@
  * Plugin Name:          Classic SEO
  * Plugin URI:           https://github.com/ClassicPress/classicpress-seo
  * Description:          Classic SEO is the first SEO plugin built specifically to work with ClassicPress. The plugin contains many essential SEO tools to help optimize your website.
- * Version:              2.1.2
+ * Version:              2.1.3
  * Author:               ClassicPress
  * Author URI:           https://github.com/ClassicPress
  * License:              GPL v2 or later
@@ -34,7 +34,7 @@ class Classic_SEO {
 	 *
 	 * @var string
 	 */
-	public $version = '2.1.2';
+	public $version = '2.1.3';
 
 	/**
 	 * Classic SEO database version.

--- a/includes/admin/class-admin-helper.php
+++ b/includes/admin/class-admin-helper.php
@@ -41,8 +41,7 @@ class Admin_Helper {
 	 * @return string
 	 */
 	public static function get_icon() {
-		$icon_svg = file_get_contents( CPSEO()->plugin_url() . '/assets/admin/img/classic-seo-dashicon-white-on-transparent.svg' );
-		return $icon_svg;
+		return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 138 138" fill-rule="evenodd" stroke-miterlimit="10" fill="#fff" stroke-width=".079" stroke-opacity=".5"><path d="M37.748 73.565c10.037-9.394 21.26-20.896 28.744-44.226l-9.56-5.87L89.264 5.44l1.774 38.487-9.453-5.637c-32.92 50.832-69.48 56.248-76.2 47.53l.292.14c11.087 5.217 25.82-6.538 32.064-12.395h-.003z"/><path d="M40.653 92.726h21.563v40.102H40.653z"/><path d="M112.836 5.86h20.423v126.966h-20.423z"/><path d="M5.393 109.893h20.55v22.93H5.393z"/><path d="M76.927 65.15h21.2v67.67h-21.2z"/></svg>';
 	}
 
 	/**

--- a/includes/class-update-client-tweaks.php
+++ b/includes/class-update-client-tweaks.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Classic_SEO;
+
+use Classic_SEO\Helper;
+
+class updateClientTweaks {		
+
+	public function __construct() {
+		// Fix images folder for Update Manager.
+		add_filter( 'codepotent_update_manager_classicpress-seo/classicpress-seo.php_image_path', [ $this, 'fix_update_manager_images' ] );
+		add_filter( 'codepotent_update_manager_classicpress-seo/classicpress-seo.php_image_url', [ $this, 'fix_update_manager_images' ] );
+		add_filter( 'codepotent_update_manager_filter_classicpress-seo/classicpress-seo.php_client_request', [ $this, 'anonymous_data_collection' ] );
+	}
+
+	/**
+	 * Fix images folder for Update Manager.
+	 */
+	public function fix_update_manager_images( $folder ) {
+	trigger_error(preg_replace( '/' . basename( CPSEO_PATH ) . '\/images$/', basename( CPSEO_PATH ) . '/assets/images', $folder ));
+		return preg_replace( '/' . basename( CPSEO_PATH ) . '\/images$/', basename( CPSEO_PATH ) . '/assets/images', $folder );
+	}
+
+	/**
+	 * Handle anonymous data collectin.
+	 */
+	public function anonymous_data_collection( $body ) {
+		if( ! Helper::get_settings( 'general.cpseo_usage_tracking' ) ) {
+			$body['sfum'] = 'no-log';
+		}
+		return $body;
+	}
+
+}
+
+new updateClientTweaks;

--- a/includes/class-update-client.php
+++ b/includes/class-update-client.php
@@ -6,7 +6,7 @@
  * Author: Simone Fioravanti
  * Author URI: https://software.gieffeedizioni.it
  * API Version: 2.0.0
- * Last modified on Update Manager release: 2.4.3
+ * Last modified on Update Manager release: 2.5.0
  * -----------------------------------------------------------------------------
  * This is free software released under the terms of the General Public License,
  * version 2, or later. It is distributed WITHOUT ANY WARRANTY; without even the
@@ -14,7 +14,7 @@
  * text of the license is available at https://www.gnu.org/licenses/gpl-2.0.txt.
  * -----------------------------------------------------------------------------
  * Copyright 2021,		John Alarcon (Code Potent)
- *           2021-2022,	Simone Fioravanti
+ *           2021-2023,	Simone Fioravanti
  * -----------------------------------------------------------------------------
  */
 
@@ -23,6 +23,11 @@ namespace Classic_SEO\UpdateClient;
 
 // EDIT: URL where Update Manager is installed; with trailing slash!
 const UPDATE_SERVER = 'https://www.cpseo.net/';
+
+// EDIT: Choose what to do in ClassicPress v.2 and above.
+//       Set to true to disable UpdateClient if updates are provided
+//       using the Classicpress Plugin Directory.
+const USE_DIRECTORY = true;
 
 // EDIT: Comment this out and fill with the first part of the url
 //       of your Download link to make sure that updates
@@ -37,7 +42,11 @@ if (!defined('ABSPATH')) {
 	die();
 }
 
-use Classic_SEO\Helper;
+// Should directory take over?
+$running_on = function_exists('classicpress_version') ? classicpress_version() : '0';
+if (USE_DIRECTORY && version_compare($running_on, '2', '>=')) {
+	return;
+}
 
 /**
  * Remote updater class for ClassicPress plugin and themes.
@@ -70,6 +79,9 @@ class UpdateClient {
 	 * saving this value will cut an extra HTTP call to the update server.
 	 */
 	private $component_data = '';
+
+	private $identifier     = null;
+	private $server_slug    = null;
 
 	/**
 	 * Constructor.
@@ -581,11 +593,6 @@ class UpdateClient {
 
 		// Initialize the data to be posted.
 		$body = apply_filters('codepotent_update_manager_filter_'.$this->config['id'].'_client_request', $this->config['post']);
-
-		// Add opt out data tracking - Stats for Update manager
-		if( ! Helper::get_settings( 'general.cpseo_usage_tracking' ) ) {
-			$body['sfum'] = 'no-log';
-		}
 
 		if ($action === 'plugin_information') {
 

--- a/includes/modules/redirections/class-redirector.php
+++ b/includes/modules/redirections/class-redirector.php
@@ -139,7 +139,9 @@ class Redirector {
 		}
 
 		// Debug if on.
-		$this->do_debugging();
+		if ( array() !== $this->matched ) {
+			$this->do_debugging();
+		}
 
 		// @codeCoverageIgnoreStart
 		if ( true === $this->do_filter( 'redirection/add_query_string', true ) && Str::is_non_empty( $this->query_string ) ) {
@@ -224,7 +226,6 @@ class Redirector {
 		if ( null === $pre || ! is_array( $pre ) ) {
 			return;
 		}
-
 		$this->matched     = $pre;
 		$this->redirect_to = $pre['url_to'];
 	}

--- a/includes/modules/rich-snippet/class-snippet-shortcode.php
+++ b/includes/modules/rich-snippet/class-snippet-shortcode.php
@@ -35,23 +35,6 @@ class Snippet_Shortcode {
 		if ( ! is_admin() ) {
 			$this->filter( 'the_content', 'add_review_to_content', 11 );
 		}
-
-		if ( ! function_exists( 'register_block_type' ) ) {
-			return;
-		}
-
-		register_block_type(
-			'cpseo/rich-snippet',
-			[
-				'render_callback' => [ $this, 'rich_snippet' ],
-				'attributes'      => [
-					'id' => [
-						'default' => '',
-						'type'    => 'integer',
-					],
-				],
-			]
-		);
 	}
 
 	/**

--- a/includes/replace-variables/class-post-variables.php
+++ b/includes/replace-variables/class-post-variables.php
@@ -317,6 +317,34 @@ class Post_Variables extends Advanced_Variables {
 		return $has ? wp_strip_all_tags( $this->args->post_excerpt ) : null;
 	}
 
+
+	/**
+	 * Replace single_month_title deprecated function.
+	 *
+	 * @return string|false|void False if there's no valid title for the month. Title when retrieving.
+	 */
+	private function single_month_title( $prefix = '', $display = true ) {
+		global $wp_locale;
+
+		$m        = get_query_var( 'm' );
+		$year     = get_query_var( 'year' );
+		$monthnum = get_query_var( 'monthnum' );
+
+		if ( ! empty( $monthnum ) && ! empty( $year ) ) {
+			$my_year  = $year;
+			$my_month = $wp_locale->get_month( $monthnum );
+		} elseif ( ! empty( $m ) ) {
+			$my_year  = substr( $m, 0, 4 );
+			$my_month = $wp_locale->get_month( substr( $m, 4, 2 ) );
+		}
+
+		if ( empty( $my_month ) ) {
+			return false;
+		}
+
+		return  ' ' . $my_month . $prefix . $my_year;
+	}
+
 	/**
 	 * Get the date of the post to use as a replacement.
 	 *
@@ -337,7 +365,7 @@ class Post_Variables extends Advanced_Variables {
 			return get_the_date( $format );
 		}
 
-		$replacement = single_month_title( ' ', false );
+		$replacement = $this->single_month_title();
 		if ( Str::is_non_empty( $replacement ) ) {
 			return $replacement;
 		}

--- a/includes/replace-variables/class-post-variables.php
+++ b/includes/replace-variables/class-post-variables.php
@@ -317,7 +317,6 @@ class Post_Variables extends Advanced_Variables {
 		return $has ? wp_strip_all_tags( $this->args->post_excerpt ) : null;
 	}
 
-
 	/**
 	 * Replace single_month_title deprecated function.
 	 *

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 == Classic SEO ==
 
 Description:       Classic SEO is the first SEO plugin built specifically to work with ClassicPress. The plugin contains many essential SEO tools to help optimize your website.
-Version:           2.1.2
+Version:           2.1.3
 Text Domain:       cpseo
 Domain Path:       /languages
 Requires PHP:      7.0
@@ -57,6 +57,9 @@ If you need support for Classic SEO or find a bug, you have threee choices:
 
 
 == Changelog ==
+**v 2.1.3 / 2023-05-25**
+* FIXED: SSL issues, deprecations
+
 **v 2.1.2 / 2023-02-03**
 * REMOVED: Remove REST API /disconnectSite endpoint (#150)
 


### PR DESCRIPTION
The function `single_month_title` is deprecated in ClassicPress 1.5 and throws a warning.
This PR add a method to `Post_Variables` to get the same result without calling the function.